### PR TITLE
Add gadt declaration in Metaocaml dubious evidence example

### DIFF
--- a/src/dubious-evidence.md
+++ b/src/dubious-evidence.md
@@ -147,7 +147,7 @@ trusted without being fully evaluated:
      ```
      ```ocaml
      (* Counterexample by Jeremy Yallop *)
-     open Tgadt_decl
+     type _ t = T : string t
 
      let f : type a. a t option code -> a -> unit code =
        fun c x -> .< match .~c with


### PR DESCRIPTION
It is a bit of white lie, but it's more understandable than the
correct example, which is linked anyway.