### PR TITLE
Fix first example in "intersecting references"

### DIFF
--- a/src/intersecting-references.md
+++ b/src/intersecting-references.md
@@ -43,7 +43,7 @@ references is unsound:
 (* Suppose we have types nat and pos,
    where nat is nonnegative integers
    and pos is its subtype of positive integers *)
-let x : nat ref ∧ pos ref = ref 0 in
+let x : nat ref ∧ pos ref = ref 1 in
 let () = (x := 0) in   (* typechecks: x is a nat ref *)
 let z : pos = !x in    (* typechecks: x is a pos ref *)
 z : pos                (* now we have the positive number zero *)


### PR DESCRIPTION
The `nat ref ∧ pos ref` cell should be initialized to hold `1` (or any
other `pos`), not `0`, so that it's a valid `pos ref`.

wchargin-branch: intersecting-references-pos-init
